### PR TITLE
0051-spider-fresno_housing

### DIFF
--- a/city_scrapers/spiders/fresno_housing.py
+++ b/city_scrapers/spiders/fresno_housing.py
@@ -1,0 +1,85 @@
+from city_scrapers_core.constants import BOARD
+from city_scrapers_core.items import Meeting
+from city_scrapers_core.spiders import CityScrapersSpider
+from datetime import date
+
+class FresnoHousingSpider(CityScrapersSpider):
+    name = "fresno_housing"
+    agency = "Fresno Housing Authority"
+    timezone = "America/Chicago"
+    #start_urls = ["https://fresnohousing.org/about-us/board-documents/"]
+    #current_year = date.today().year
+    start_urls = ["https://fresnohousing.org/about-us/board-documents/board-documents-2022/"]
+
+    def parse(self, response):
+        """
+        `parse` should always `yield` Meeting items.
+
+        Change the `_parse_title`, `_parse_start`, etc methods to fit your scraping
+        needs.
+        """
+        for item in response.css(".listitems"):
+            meeting = Meeting(
+                title=self._parse_title(item),
+                description=self._parse_description(item),
+                classification=self._parse_classification(item),
+                start=self._parse_start(item),
+                end=self._parse_end(item),
+                all_day=self._parse_all_day(item),
+                time_notes=self._parse_time_notes(item),
+                location=self._parse_location(item),
+                links=self._parse_links(item),
+                source=self._parse_source(response),
+            )
+
+            meeting["status"] = self._get_status(meeting)
+            meeting["id"] = self._get_id(meeting)
+
+            yield meeting
+
+    def _parse_title(self, item):
+        """Parse or generate meeting title."""
+        title = item.css(".left::text").get()
+        if "special" in title.lower():
+            return "Special Board Meeting"
+        return "Regular Board Meeting"
+
+    def _parse_description(self, item):
+        """Parse or generate meeting description."""
+        return ""
+
+    def _parse_classification(self, item):
+        """Parse or generate classification from allowed options."""
+        return BOARD
+
+    def _parse_start(self, item):
+        """Parse start datetime as a naive datetime object."""
+        return None
+
+    def _parse_end(self, item):
+        """Parse end datetime as a naive datetime object. Added by pipeline if None"""
+        return None
+
+    def _parse_time_notes(self, item):
+        """Parse any additional notes on the timing of the meeting"""
+        return ""
+
+    def _parse_all_day(self, item):
+        """Parse or generate all-day status. Defaults to False."""
+        return False
+
+    def _parse_location(self, item):
+        """Parse or generate location."""
+        return {
+            "address": "1260 Fulton Street (2nd Floor), Fresno, CA. 93721",
+            "name": "",
+        }
+
+    def _parse_links(self, item):
+        """Parse or generate links."""
+        href = item.css(".readmore::attr(href)").get()
+        return [{"href": href, "title": "Meeting Packet"}]
+
+    def _parse_source(self, response):
+        """Parse or generate source."""
+        return response.url


### PR DESCRIPTION
@jpt-c 
keep running into following error when running spider: '<' not supported between instances of 'NoneType' and 'datetime.datetime'
don't think i'm currently using datetime anywhere, originally was for the start_urls but commented out those lines to try to get something to work, still getting the error.

## Summary

**Issue:** #0051

Replace "ISSUE_NUMBER" with the number of your issue so that GitHub will link this pull request with the issue and make review easier.

## Checklist

All checks are run in [GitHub Actions](https://github.com/features/actions). You'll be able to see the results of the checks at the bottom of the pull request page after it's been opened, and you can click on any of the specific checks listed to see the output of each step and debug failures.

- [ ] Tests are implemented
- [ ] All tests are passing
- [ ] Style checks run (see [documentation](https://cityscrapers.org/docs/development/) for more details)
- [ ] Style checks are passing
- [ ] Code comments from template removed

## Questions

Include any questions you have about what you're working on.
