### PR TITLE
0046 spider san joaquin river conservancy

### DIFF
--- a/city_scrapers/spiders/san_joaquin_river_conservancy.py
+++ b/city_scrapers/spiders/san_joaquin_river_conservancy.py
@@ -1,4 +1,4 @@
-from datetime import datetime, date
+from datetime import datetime
 
 from city_scrapers_core.constants import BOARD
 from city_scrapers_core.items import Meeting
@@ -18,15 +18,14 @@ class SanJoaquinRiverConservancySpider(CityScrapersSpider):
         Change the `_parse_title`, `_parse_start`, etc methods to fit your scraping
         needs.
         """
-        td_sel_str = "td[style=\"text-align: center;\"][align=\"left\"]"
+        td_sel_str = 'td[style="text-align: center;"][align="left"]'
         td_response = response.css(td_sel_str)
         td_sel_list = td_response.css("*")[1::]
 
         # Dictionary to store board meeting information
         # Keys: Title (str)
-        # Values: Selection Objects 
+        # Values: Selection Objects
         board_meeting_dict = {}
-        workshop_dict = {}
 
         # Parsing the td element sequentially
         cur_meeting = None
@@ -74,7 +73,7 @@ class SanJoaquinRiverConservancySpider(CityScrapersSpider):
 
     def _parse_start(self, item):
         """Parse start datetime as a naive datetime object."""
-        date_str_list = item[0].split('-')[0].split()
+        date_str_list = item[0].split("-")[0].split()
         month = datetime.strptime(date_str_list[0].strip(), "%B").month
         day = date_str_list[1].strip()
 
@@ -92,7 +91,7 @@ class SanJoaquinRiverConservancySpider(CityScrapersSpider):
         for sel in item[1]:
             agenda_link = sel.css("::attr(href)").get()
             if agenda_header in agenda_link:
-                year = agenda_link[len(agenda_header):len(agenda_header)+4]
+                year = agenda_link[len(agenda_header) : len(agenda_header) + 4]
         start = f"{year} {int(month):02} {int(day):02} {meeting_time}"
 
         return datetime.strptime(start, "%Y %m %d %H:%M:%S")
@@ -103,9 +102,11 @@ class SanJoaquinRiverConservancySpider(CityScrapersSpider):
 
     def _parse_time_notes(self, item):
         """Parse any additional notes on the timing of the meeting"""
-        time_notes_str = ("Scheduled meetings are subject to change. "
-                          "Refer to Agenda if available. For more information "
-                          "email info@sjrc.ca.gov or call (559) 253-7324.")
+        time_notes_str = (
+            "Scheduled meetings are subject to change. "
+            "Refer to Agenda if available. For more information "
+            "email info@sjrc.ca.gov or call (559) 253-7324."
+        )
         return time_notes_str
 
     def _parse_all_day(self, item):
@@ -124,7 +125,7 @@ class SanJoaquinRiverConservancySpider(CityScrapersSpider):
         link_dict = {}
         for sel in item[1]:
             link = sel.css("::attr(href)").get()
-            title = link.split("/")[len(link.split("/"))-1].split(".")[0]
+            title = link.split("/")[len(link.split("/")) - 1].split(".")[0]
             link_dict[link] = title
         return link_dict
 

--- a/city_scrapers/spiders/san_joaquin_river_conservancy.py
+++ b/city_scrapers/spiders/san_joaquin_river_conservancy.py
@@ -1,0 +1,133 @@
+from datetime import datetime, date
+
+from city_scrapers_core.constants import BOARD
+from city_scrapers_core.items import Meeting
+from city_scrapers_core.spiders import CityScrapersSpider
+
+
+class SanJoaquinRiverConservancySpider(CityScrapersSpider):
+    name = "san_joaquin_river_conservancy"
+    agency = "San Joaquin River Conservancy"
+    timezone = "America/Chicago"
+    start_urls = ["http://sjrc.ca.gov/Board/"]
+
+    def parse(self, response):
+        """
+        `parse` should always `yield` Meeting items.
+
+        Change the `_parse_title`, `_parse_start`, etc methods to fit your scraping
+        needs.
+        """
+        td_sel_str = "td[style=\"text-align: center;\"][align=\"left\"]"
+        td_response = response.css(td_sel_str)
+        td_sel_list = td_response.css("*")[1::]
+
+        # Dictionary to store board meeting information
+        # Keys: Title (str)
+        # Values: Selection Objects 
+        board_meeting_dict = {}
+        workshop_dict = {}
+
+        # Parsing the td element sequentially
+        cur_meeting = None
+        for sel in td_sel_list:
+            title = sel.css("::text").get()
+            if sel.css("p strong") and "Board Meeting" in title:
+                cur_meeting = title
+                board_meeting_dict[cur_meeting] = []
+            if sel.css("h3"):
+                cur_meeting = None
+            if cur_meeting is not None and sel.css("a"):
+                board_meeting_dict[cur_meeting].append(sel)
+
+        for title, sel_list in board_meeting_dict.items():
+            item = (title, sel_list)
+            meeting = Meeting(
+                title=self._parse_title(item),
+                description=self._parse_description(item),
+                classification=self._parse_classification(item),
+                start=self._parse_start(item),
+                end=self._parse_end(item),
+                all_day=self._parse_all_day(item),
+                time_notes=self._parse_time_notes(item),
+                location=self._parse_location(item),
+                links=self._parse_links(item),
+                source=self._parse_source(response),
+            )
+
+            meeting["status"] = self._get_status(meeting)
+            meeting["id"] = self._get_id(meeting)
+
+            yield meeting
+
+    def _parse_title(self, item):
+        """Parse or generate meeting title."""
+        return item[0] if item else ""
+
+    def _parse_description(self, item):
+        """Parse or generate meeting description."""
+        return ""
+
+    def _parse_classification(self, item):
+        """Parse or generate classification from allowed options."""
+        return BOARD
+
+    def _parse_start(self, item):
+        """Parse start datetime as a naive datetime object."""
+        date_str_list = item[0].split('-')[0].split()
+        month = datetime.strptime(date_str_list[0].strip(), "%B").month
+        day = date_str_list[1].strip()
+
+        # Meetings start at 10:00 AM between March and October
+        # Otherwise, meeting start at 10:30 AM
+        if int(month) >= 3 and int(month) <= 10:
+            meeting_time = "10:00:00"
+        else:
+            meeting_time = "10:30:00"
+
+        # Parsing the current year from the agenda link
+        # Defaults to current year if parsing fails
+        year = datetime.now().year
+        agenda_header = "http://sjrc.ca.gov/wp-content/uploads/"
+        for sel in item[1]:
+            agenda_link = sel.css("::attr(href)").get()
+            if agenda_header in agenda_link:
+                year = agenda_link[len(agenda_header):len(agenda_header)+4]
+        start = f"{year} {int(month):02} {int(day):02} {meeting_time}"
+
+        return datetime.strptime(start, "%Y %m %d %H:%M:%S")
+
+    def _parse_end(self, item):
+        """Parse end datetime as a naive datetime object. Added by pipeline if None"""
+        return None
+
+    def _parse_time_notes(self, item):
+        """Parse any additional notes on the timing of the meeting"""
+        time_notes_str = ("Scheduled meetings are subject to change. "
+                          "Refer to Agenda if available. For more information "
+                          "email info@sjrc.ca.gov or call (559) 253-7324.")
+        return time_notes_str
+
+    def _parse_all_day(self, item):
+        """Parse or generate all-day status. Defaults to False."""
+        return False
+
+    def _parse_location(self, item):
+        """Parse or generate location."""
+        return {
+            "address": "5469 E. Olive Ave., Fresno, CA 93727",
+            "name": "Fresno Metropolitan Flood Control District Board Room",
+        }
+
+    def _parse_links(self, item):
+        """Parse or generate links."""
+        link_dict = {}
+        for sel in item[1]:
+            link = sel.css("::attr(href)").get()
+            title = link.split("/")[len(link.split("/"))-1].split(".")[0]
+            link_dict[link] = title
+        return link_dict
+
+    def _parse_source(self, response):
+        """Parse or generate source."""
+        return response.url

--- a/city_scrapers/spiders/san_joaquin_river_conservancy.py
+++ b/city_scrapers/spiders/san_joaquin_river_conservancy.py
@@ -13,10 +13,8 @@ class SanJoaquinRiverConservancySpider(CityScrapersSpider):
 
     def parse(self, response):
         """
-        `parse` should always `yield` Meeting items.
-
-        Change the `_parse_title`, `_parse_start`, etc methods to fit your scraping
-        needs.
+        Main parse method for the San Joaquin River Conservancy
+        Yields Meeting objects
         """
         td_sel_str = 'td[style="text-align: center;"][align="left"]'
         td_response = response.css(td_sel_str)

--- a/tests/files/san_joaquin_river_conservancy.html
+++ b/tests/files/san_joaquin_river_conservancy.html
@@ -1,0 +1,480 @@
+<!doctype html>
+<!--[if lt IE 7]> <html class="no-js ie6 oldie" lang="en"> <![endif]-->
+<!--[if IE 7]>    <html class="no-js ie7 oldie" lang="en"> <![endif]-->
+<!--[if IE 8]>    <html class="no-js ie8 oldie" lang="en"> <![endif]-->
+<!--[if IE 9]>    <html class="no-js ie9 oldie" lang="en"> <![endif]-->
+<!--[if (gt IE 9)]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
+<head>
+<!--
+California State Template
+Version 5.0.5
+ 
+Based on Twitter Bootstrap
+-->
+<meta charset="utf-8">
+<!-- TemplateBeginEditable name="doctitle" -->
+<!-- TemplateEndEditable -->
+<!-- TemplateBeginEditable name="MetaTags" -->
+<meta name="Author" content="State of California" />
+<meta name="Description" content="The San Joaquin River Conservancy is a regionally governed agency created to develop and manage the San Joaquin River Parkway" /><meta name="Keywords" content="California, government" />
+<!-- TemplateEndEditable -->
+<!-- head content, for all pages -->
+<!-- Use highest compatibility mode -->
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+<!-- http://t.co/dKP3o1e -->
+<meta name="HandheldFriendly" content="True">
+<!-- for Blackberry, AvantGo -->
+<meta name="MobileOptimized" content="320">
+<!-- for Windows mobile -->
+<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+
+<!-- Google Fonts -->
+<link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700' rel='stylesheet' type='text/css'>
+
+<!-- For all browsers -->
+<link rel="stylesheet" href="http://sjrc.ca.gov/wp-content/themes/cagov505/css/cagov.core.css">
+
+<script src="/js/search.js"></script><!--
+Step 3
+Select a color scheme:
+<link rel="stylesheet" href="/css/colorscheme-eureka.css">
+<link rel="stylesheet" href="/css/colorscheme-mono.css">
+<link rel="stylesheet" href="/css/colorscheme-oceanside.css">
+<link rel="stylesheet" href="/css/colorscheme-orangecounty.css">
+<link rel="stylesheet" href="/css/colorscheme-pasorobles.css">
+<link rel="stylesheet" href="/css/colorscheme-santabarbara.css">
+<link rel="stylesheet" href="/css/colorscheme-sacramento.css">
+<link rel="stylesheet" href="/css/colorscheme-sierra.css">
+<link rel="stylesheet" href="/css/colorscheme-trinity.css">
+-->
+
+<link rel="stylesheet" href="http://sjrc.ca.gov/wp-content/themes/cagov505/css/colorscheme-sacramento.css">
+
+<!-- selectivizr.com, emulates CSS3 pseudo-classes and attribute selectors in Internet Explorer 6-8 -->
+<!--[if (lt IE 9) & (!IEMobile)]>
+<script src="/js/libs/selectivizr-min.js"></script>
+<![endif]-->
+
+
+<!-- Load jQuery from CDN with fallback to local copy -->
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js" type="text/javascript"></script>
+<script>
+    //Fall back to local copy if no jquery found
+    if (typeof jQuery == 'undefined') {
+        document.write(unescape("%3Cscript src='/js/libs/jquery-3.2.1.min.js' type='text/javascript'%3E%3C/script%3E"));
+    }
+</script>
+<!-- Load jQuery migrate from CDN with fallback to local copy -->
+<script src="https://code.jquery.com/jquery-migrate-3.0.1.min.js"></script>
+<script>
+    //Fall back to local copy if no jQuery migrate found
+    if (typeof jQuery.migrateWarnings == 'undefined') { // or typeof jQuery.fn.live == 'undefined'
+        document.write(unescape("%3Cscript src='/js/libs/jquery-migrate-3.0.1.js' type='text/javascript'%3E%3C/script%3E"));
+    }
+
+</script>
+
+
+<!-- For iPad 3-->
+<link rel="apple-touch-icon" sizes="144x144" href="http://sjrc.ca.gov/wp-content/themes/cagov505/images/template2014/apple-touch-icon-144x144.png">
+<!-- For iPhone 4 -->
+<link rel="apple-touch-icon" sizes="114x114" href="http://sjrc.ca.gov/wp-content/themes/cagov505/images/template2014/apple-touch-icon-114x114.png">
+<!-- For iPad 1-->
+<link rel="apple-touch-icon" sizes="72x72" href="http://sjrc.ca.gov/wp-content/themes/cagov505/images/template2014/apple-touch-icon-72x72.png">
+<!-- For iPhone 3G, iPod Touch and Android -->
+<link rel="apple-touch-icon" href="http://sjrc.ca.gov/wp-content/themes/cagov505/images/template2014/apple-touch-icon-57x57.png">
+<!-- For Nokia -->
+<link rel="shortcut icon" href="http://sjrc.ca.gov/wp-content/themes/cagov505/images/template2014/apple-touch-icon-57x57.png">
+<!-- For everything else -->
+<link rel="shortcut icon" href="http://sjrc.ca.gov/wp-content/themes/cagov505/favicon.ico">
+
+<!-- Activate ClearType for Mobile IE -->
+<!--[if IE]>
+<meta http-equiv="cleartype" content="on">
+<![endif]-->
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!--[if lt IE 9]>
+  <script src="/js/libs/html5shiv.min.js"></script>
+  <script src="/js/libs/respond.min.js"></script>
+<![endif]-->
+<!-- Include Google Analytics -->
+<script type="text/javascript">
+
+  var _gaq = _gaq || [];
+    _gaq.push(['_setAccount', 'UA-59627195-7']); // Step 4: your google analytics profile code, either from your own google account, or contact eServices to have one set up for you
+  _gaq.push(['_gat._anonymizeIp']);
+  _gaq.push(['_setDomainName', '.ca.gov']);
+  _gaq.push(['_trackPageview']);
+
+  _gaq.push(['b._setAccount', 'UA-3419582-2']); // statewide analytics - do not remove or change
+  _gaq.push(['b._setDomainName', '.ca.gov']);
+  _gaq.push(['b._trackPageview']);
+
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+
+</script>
+<!-- TemplateBeginEditable name="head" -->
+<title>San Joaquin River Conservancy Board &#8211; San Joaquin River Conservancy</title>
+<meta name='robots' content='max-image-preview:large' />
+<link rel='dns-prefetch' href='//s.w.org' />
+<script type="text/javascript">
+window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/svg\/","svgExt":".svg","source":{"concatemoji":"http:\/\/sjrc.ca.gov\/wp-includes\/js\/wp-emoji-release.min.js?ver=6.0.2"}};
+/*! This file is auto-generated */
+!function(e,a,t){var n,r,o,i=a.createElement("canvas"),p=i.getContext&&i.getContext("2d");function s(e,t){var a=String.fromCharCode,e=(p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,e),0,0),i.toDataURL());return p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,t),0,0),e===i.toDataURL()}function c(e){var t=a.createElement("script");t.src=e,t.defer=t.type="text/javascript",a.getElementsByTagName("head")[0].appendChild(t)}for(o=Array("flag","emoji"),t.supports={everything:!0,everythingExceptFlag:!0},r=0;r<o.length;r++)t.supports[o[r]]=function(e){if(!p||!p.fillText)return!1;switch(p.textBaseline="top",p.font="600 32px Arial",e){case"flag":return s([127987,65039,8205,9895,65039],[127987,65039,8203,9895,65039])?!1:!s([55356,56826,55356,56819],[55356,56826,8203,55356,56819])&&!s([55356,57332,56128,56423,56128,56418,56128,56421,56128,56430,56128,56423,56128,56447],[55356,57332,8203,56128,56423,8203,56128,56418,8203,56128,56421,8203,56128,56430,8203,56128,56423,8203,56128,56447]);case"emoji":return!s([129777,127995,8205,129778,127999],[129777,127995,8203,129778,127999])}return!1}(o[r]),t.supports.everything=t.supports.everything&&t.supports[o[r]],"flag"!==o[r]&&(t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&t.supports[o[r]]);t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&!t.supports.flag,t.DOMReady=!1,t.readyCallback=function(){t.DOMReady=!0},t.supports.everything||(n=function(){t.readyCallback()},a.addEventListener?(a.addEventListener("DOMContentLoaded",n,!1),e.addEventListener("load",n,!1)):(e.attachEvent("onload",n),a.attachEvent("onreadystatechange",function(){"complete"===a.readyState&&t.readyCallback()})),(e=t.source||{}).concatemoji?c(e.concatemoji):e.wpemoji&&e.twemoji&&(c(e.twemoji),c(e.wpemoji)))}(window,document,window._wpemojiSettings);
+</script>
+<style type="text/css">
+img.wp-smiley,
+img.emoji {
+	display: inline !important;
+	border: none !important;
+	box-shadow: none !important;
+	height: 1em !important;
+	width: 1em !important;
+	margin: 0 0.07em !important;
+	vertical-align: -0.1em !important;
+	background: none !important;
+	padding: 0 !important;
+}
+</style>
+	<link rel='stylesheet' id='ai1ec_style-css'  href='//sjrc.ca.gov/wp-content/plugins/all-in-one-event-calendar/public/themes-ai1ec/vortex/css/ai1ec_parsed_css.css?ver=3.0.0' type='text/css' media='all' />
+<link rel='stylesheet' id='wp-block-library-css'  href='http://sjrc.ca.gov/wp-includes/css/dist/block-library/style.min.css?ver=6.0.2' type='text/css' media='all' />
+<style id='global-styles-inline-css' type='text/css'>
+body{--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink: #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange: #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan: #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue: #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple: #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);--wp--preset--duotone--dark-grayscale: url('#wp-duotone-dark-grayscale');--wp--preset--duotone--grayscale: url('#wp-duotone-grayscale');--wp--preset--duotone--purple-yellow: url('#wp-duotone-purple-yellow');--wp--preset--duotone--blue-red: url('#wp-duotone-blue-red');--wp--preset--duotone--midnight: url('#wp-duotone-midnight');--wp--preset--duotone--magenta-yellow: url('#wp-duotone-magenta-yellow');--wp--preset--duotone--purple-green: url('#wp-duotone-purple-green');--wp--preset--duotone--blue-orange: url('#wp-duotone-blue-orange');--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium: 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large: 42px;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color: var(--wp--preset--color--white) !important;}.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
+</style>
+<link rel='stylesheet' id='style-css'  href='http://sjrc.ca.gov/wp-content/themes/cagov505/style.css?ver=6.0.2' type='text/css' media='all' />
+<link rel="https://api.w.org/" href="http://sjrc.ca.gov/wp-json/" /><link rel="alternate" type="application/json" href="http://sjrc.ca.gov/wp-json/wp/v2/pages/55" /><link rel="canonical" href="http://sjrc.ca.gov/board/" />
+<link rel='shortlink' href='http://sjrc.ca.gov/?p=55' />
+<link rel="alternate" type="application/json+oembed" href="http://sjrc.ca.gov/wp-json/oembed/1.0/embed?url=http%3A%2F%2Fsjrc.ca.gov%2Fboard%2F" />
+<link rel="alternate" type="text/xml+oembed" href="http://sjrc.ca.gov/wp-json/oembed/1.0/embed?url=http%3A%2F%2Fsjrc.ca.gov%2Fboard%2F&#038;format=xml" />
+<!-- TemplateEndEditable -->
+
+</head>
+
+<!-- possible body classes are "primary" and "two-column" -->
+<body class="">
+
+<header role="banner" id="header" class="global-header fixed">
+	<div id="skip-to-content"><a href="#main-content">Skip to Main Content</a></div>
+		<!-- <div class="alert alert-warning alert-dismissible alert-banner" role="alert">
+    <div class="container">
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <span class="alert-level"><span class="ca-gov-icon-important" aria-hidden="true"></span>Urgent Energy Conservation Needed:</span><span class="alert-text"> Raise your AC to 78 at 3 p.m. - 10 p.m. &bull; Turn off unnecessary lights & appliances  &bull;  Learn more flexalert.org</span> <a href="https://flexalert.org" class="alert-link btn btn-default btn-xs">More Information</a>
+    </div>
+</div> -->		<!-- Include Utility Header -->
+		<div class="utility-header">
+    <div class="container">
+        <div class="group">
+            <div class="third">              
+                <ul class="utility-links social-media-links">
+					<li><div class="header-cagov-logo"><a href="https://www.ca.gov/"><img src="http://sjrc.ca.gov/wp-content/themes/cagov505/images/Ca-Gov-Logo-Gold.svg" alt="CA.gov" /></a></div></li>
+                    <li><a href="/" title="Utility home link"><span class="ca-gov-icon-home" aria-hidden="true"></span><span class="sr-only">Home</span></a></li>
+
+					 			<!-- start v5 Utility Left edit -->
+
+<!-- end v5 Utility Left edit -->		 
+				</ul>
+			</div>
+            <div class="two-thirds settings-links p-t-sm">
+                <ul class="utility-links ">
+					<li><a href="/contact/">Contact Us</a></li>
+                    <li><button class="btn btn-xs btn-primary" data-toggle="collapse" href="#siteSettings" aria-expanded="false" aria-controls="siteSettings"><span class="ca-gov-icon-gear" aria-hidden="true"></span> Settings</button></li>
+					<li><div id="google_translate_element"></div></li>
+					<script type="text/javascript">
+					function googleTranslateElementInit() {
+						new google.translate.TranslateElement({pageLanguage: 'en', layout: google.translate.TranslateElement.InlineLayout.SIMPLE}, 'google_translate_element');
+					}
+					</script> 
+					<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+					<style>
+						div#google_translate_element div.goog-te-gadget-simple{background-color:#153554;}
+						div#google_translate_element div.goog-te-gadget-simple{border-color:#153554;}
+						div#google_translate_element div.goog-te-gadget-simple a.goog-te-menu-value span{color:#FFFFFF}
+						div#google_translate_element div.goog-te-gadget-simple a.goog-te-menu-value span:hover{color:#fbad23;}
+						div#google_translate_element div.goog-te-gadget-simple a.goog-te-menu-value span{font-family:"Source Sans Pro", sans-serif; font-size:109%}
+						div#google_translate_element .goog-te-gadget-icon {display: none}
+					</style>
+					<li><a href="/language-translation/">Translation Notice</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</div>
+	
+		<!-- Settings Bar -->
+		<div class="site-settings section section-standout collapse collapsed" role="alert" id="siteSettings">
+    <div class="container  p-y">
+        <button type="button" class="close" data-toggle="collapse" data-target="#siteSettings" aria-expanded="false" aria-controls="siteSettings" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+
+        <div class="btn-group btn-group-justified-sm" role="group" aria-label="contrastMode">
+            <div class="btn-group"><button type="button" class="btn btn-standout disableHighContrastMode">Default</button></div>
+            <div class="btn-group"><button type="button" class="btn btn-standout enableHighContrastMode">High Contrast</button></div>
+        </div>
+
+        <div class="btn-group" role="group" aria-label="textSizeMode">
+            <div class="btn-group"><button type="button" class="btn btn-standout resetTextSize">Reset</button></div>
+            <div class="btn-group"><button type="button" class="btn btn-standout increaseTextSize"><span class="hidden-xs">Increase Font Size</span><span class="visible-xs">Font <small class="ca-gov-icon-plus-line"></small></span></button></div>
+            <div class="btn-group"><button type="button" class="btn btn-standout decreaseTextSize"><span class="hidden-xs">Decrease Font Size</span><span class="visible-xs">Font <small class="ca-gov-icon-minus-line"></small></span></button></div>
+        </div>
+               
+                <!-- <button type="button" class="btn btn-primary clipboard-activeonhover">Save links on hover</button> -->
+            
+    </div>
+</div>    
+	
+		<!-- Include Branding -->
+		<!-- header branding -->
+<div class="branding">
+<div class="header-organization-banner"><a href="/"><img src="http://sjrc.ca.gov/wp-content/themes/cagov505/images/template-logo.png" alt="San Joaquin River Conservancy Logo" /></a></div>
+</div>	
+		<!-- Include Mobile Controls -->
+		<!-- mobile navigation controls -->
+<div class="mobile-controls">
+    <span class="mobile-control-group mobile-header-icons">
+    	<!-- Add more mobile controls here. These will be on the right side of the mobile page header section -->
+    </span>
+    <div class="mobile-control-group main-nav-icons float-right">
+        <button id="nav-icon3" class="mobile-control toggle-menu float-right" aria-expanded="false" aria-controls="navigation">
+            <span></span>
+            <span></span>
+            <span></span>
+            <span></span>
+            <span class="sr-only">Menu</span>
+        </button>
+        <button class="mobile-control toggle-search">
+            <span class="ca-gov-icon-search hidden-print" aria-hidden="true"></span><span class="sr-only">Search</span>
+        </button>
+    </div>
+</div>	
+		<div class="navigation-search">
+	
+			<!-- Include Navigation -->
+			<!--
+Step 2
+Select Navigation Type:
+
+Options are: megadropdown dropdown singlelevel
+-->
+
+<nav id="navigation" class="main-navigation singlelevel auto-highlight">
+    <ul id="nav_list" class="top-level-nav">
+        <li class="home-link nav-item">
+            <a href="/" class="first-level-link" title="Home"><span id="nav_home_container" class="ca-gov-icon-home" aria-hidden="true"></span>Home</a>
+        </li>
+ 			<!-- start v5 Navigation Bar edit -->
+<li class="nav-item"><a href="/Board/" class="first-level-link" title="Board"><span class="ca-gov-icon-users"></span>Board</a></li>
+<li class="nav-item"><a href="/Recreation/" class="first-level-link" title="Recreation"><span class="ca-gov-icon-thumb-up"></span>Recreation</a></li>
+<li class="nav-item"><a href="/Projects/" class="first-level-link" title="Projects"><span class="ca-gov-icon-puzzle"></span>Projects</a></li>
+<li class="nav-item"><a href="/Partners/" class="first-level-link" title="Partners"><span class="ca-gov-icon-handshake"></span>Partners</a></li>
+<li class="nav-item"><a href="/Contact-Us/" class="first-level-link" title="Contact Us"><span class="ca-gov-icon-contact-us"></span>Contact Us</a></li>
+<li class="nav-item"><a href="/grants-and-funding/" class="first-level-link" title="Grants and Funding"><span class="ca-gov-icon-hand-money"></span>Grants and Funding</a></li>
+<!-- end v5 Navigation Bar edit -->		 
+        <li class="nav-item" id='nav-item-search'>
+            <a href="javascript:;" class="first-level-link"><span class="ca-gov-icon-search" aria-hidden="true"></span>Search</a>
+        </li>
+    </ul>
+</nav>	
+			<div id="head-search" class="search-container">
+			<!-- Include Search -->
+			<!-- Google Custom Search - /ssi/search.html-->
+
+<script type="text/javascript">
+    var cx = '001779225245372747843:g1i_vb1net0';// Step 7: Update this value with your search engine unique ID. Submit a request to the CDT Service Desk if you don't already know your unique search engine ID.
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script');
+    s[s.length - 1].parentNode.insertBefore(gcse, s[s.length - 1]);
+</script>
+
+<gcse:searchbox-only resultsUrl="/serp" enableAutoComplete="true"></gcse:searchbox-only>			</div>
+	
+		</div>
+
+	<div class="header-decoration"></div>
+</header>
+
+
+
+
+
+
+<div id="main-content" class="main-content">
+    <div class="section">
+        <main class="main-primary"> <!-- TemplateBeginEditable name="MainContent" -->
+		
+	<article id="post-55">
+	<h2>San Joaquin River Conservancy Board</h2>
+	<p style="text-align: center;"><em><br />
+<img class="alignnone wp-image-3514" src="http://sjrc.ca.gov/wp-content/uploads/2019/04/Brand-and-Logo-300x54.jpg" alt="" width="672" height="121" srcset="http://sjrc.ca.gov/wp-content/uploads/2019/04/Brand-and-Logo-300x54.jpg 300w, http://sjrc.ca.gov/wp-content/uploads/2019/04/Brand-and-Logo-768x139.jpg 768w, http://sjrc.ca.gov/wp-content/uploads/2019/04/Brand-and-Logo-1024x185.jpg 1024w, http://sjrc.ca.gov/wp-content/uploads/2019/04/Brand-and-Logo.jpg 1397w" sizes="(max-width: 672px) 100vw, 672px" /><br />
+</em></p>
+<table cellspacing="0" cellpadding="0" align="left">
+<tbody>
+<tr>
+<td width="0" height="0"></td>
+<td style="padding-left: 0px;" width="457">
+<h1 style="text-align: center;">San Joaquin River Conservancy Board</h1>
+</td>
+<td width="14"></td>
+<td width="457">
+<h1 style="text-align: center;"> Agendas, Meeting Minutes, and Board Packets</h1>
+</td>
+</tr>
+<tr>
+<td height="622"></td>
+<td style="text-align: left;" align="left" valign="top">
+<p style="text-align: justify;">The San Joaquin River Conservancy Board is composed of fifteen members, four of which are elected officials.  The chairperson of the board rotates every two years among the mayor or designated council member of the City of Fresno, the member of the Board of Supervisors of Madera County, and the member of the Board of Supervisors of Fresno County.</p>
+<h4 style="text-align: center;">Chairperson <strong>Bryn Forhan</strong></h4>
+<p style="text-align: center;"><em>Citizen Representative</em></p>
+<h4 style="text-align: center;">The Honorable <strong>Brett Frazier</strong></h4>
+<p style="text-align: center;"><em>Supervisor, </em><em>County of Madera</em></p>
+<h4 style="text-align: center;">The Honorable <strong>Mike Karbassi</strong></h4>
+<p style="text-align: center;"><em>Councilmember, City of Fresno</em></p>
+<h4></h4>
+<h4 style="text-align: center;">The Honorable <strong>Steve Brandau</strong></h4>
+<p style="text-align: center;"><em>Supervisor, County of Fresno</em></p>
+<h4></h4>
+<h4 style="text-align: center;">The Honorable <strong>Santos Garcia</strong></h4>
+<p style="text-align: center;"><em>Mayor, </em><em>City of Madera</em></p>
+<h4 style="text-align: center;"><strong>Carl Janzen</strong></h4>
+<p style="text-align: center;"><em>Director, </em><em>Madera Irrigation District</em></p>
+<h4></h4>
+<h4 style="text-align: center;"><strong>Julie Vance</strong></h4>
+<p style="text-align: center;"><em>Regional Manager, </em><em>Department of Fish and Wildlife</em></p>
+<h4></h4>
+<h4 style="text-align: center;"><strong>Kent Gresham</strong></h4>
+<p style="text-align: center;"><em>Sector Superintendent, </em><em>Department of Parks &amp; Recreation</em></p>
+<h4></h4>
+<h4 style="text-align: center;"><strong>John Donnelly</strong></h4>
+<p style="text-align: center;"><em>Executive Director, </em><em>Wildlife Conservation Board</em></p>
+<h4></h4>
+<h4 style="text-align: center;"><strong>Andrea Scharffer</strong></h4>
+<p style="text-align: center;"><em>Deputy Assistant Secretary, </em><em>Natural Resources Agency</em></p>
+<h4></h4>
+<h4 style="text-align: center;"><strong>Jennifer Lucchesi</strong></h4>
+<p style="text-align: center;"><em>Executive Officer, </em><em>State Lands Commission</em></p>
+<h4 align="center"></h4>
+<h4 align="center"><strong>Matt Almy</strong></h4>
+<p align="center"><em>Program Budget Manager, </em><em>Department of Finance</em></p>
+<p align="center">
+<h4 style="text-align: center;"><strong>Paul Gibson</strong></h4>
+<p style="text-align: center;"><em>Citizen Representative</em></p>
+<h4 style="text-align: center;"><strong>Vacant</strong></h4>
+<p style="text-align: center;"><em>Citizen Representative</em></p>
+<address> </address>
+<address style="text-align: center;">The San Joaquin River Conservancy Board generally holds open public meetings on the first Wednesday of each month. The meetings commence at 10:00 a.m. during the months of March through October, and at 10:30 a.m. from November through February. Scheduled meetings are subject to change. For further information or to request a copy of staff reports (available one week prior to the Board meeting), please email <a href="mailto:info@sjrc.ca.gov">info@sjrc.ca.gov</a> or call (559) 253-7324. Most meetings are held at the Fresno Metropolitan Flood Control District Board Room, located at 5469 E. Olive Ave., Fresno, CA 93727.</address>
+</td>
+<td style="text-align: center;"></td>
+<td style="text-align: center;" align="left" valign="top">
+<h2 style="text-align: center;">Calendar for 2022</h2>
+<h3>Board Meetings</h3>
+<p style="text-align: left;">Board meetings will start at 10:00 a.m. except for in-person meetings during the foggy season.  At this time, we expect our meetings to continue to be held virtually. To sign up for an email notifying you when the Board Agenda and materials are posted please go to <strong><a href="https://public.govdelivery.com/accounts/CNRA/signup/30126" target="_blank" rel="noopener">sign up page</a></strong></p>
+<p style="text-align: center;"><strong>February 2- Board Meeting </strong></p>
+<p style="text-align: center;"><strong><a href="http://sjrc.ca.gov/wp-content/uploads/2022/01/2022-Feb-SJRC-Revised-Agenda.pdf" target="_blank" rel="noopener">Revised Agenda</a>/<a href="http://sjrc.ca.gov/wp-content/uploads/2022/01/2022-February-SJRC-Board-Packet.pdf" target="_blank" rel="noopener">Packet</a>/<a href="http://sjrc.ca.gov/wp-content/uploads/2022/01/2021-December-SJRC-Draft-Minutes.pdf" target="_blank" rel="noopener">Approved Minutes</a><br />
+</strong></p>
+<p><a href="http://sjrc.ca.gov/wp-content/uploads/2022/02/Staff-Presentation-for-Feb-2022.pdf" target="_blank" rel="noopener">PowerPoint for Meeting</a></p>
+<p><a href="http://sjrc.ca.gov/wp-content/uploads/2022/02/BALL-RANCH.pdf" target="_blank" rel="noopener">Correspondence</a></p>
+<p><strong>April 6- Board Meeting</strong></p>
+<p><a href="http://sjrc.ca.gov/wp-content/uploads/2022/03/2022-April-SJRC-Agenda.pdf" target="_blank" rel="noopener">Agenda</a></p>
+<p style="text-align: center;"><strong>May 4- Board Meeting</strong></p>
+<p style="text-align: center;"><a href="http://sjrc.ca.gov/wp-content/uploads/2022/04/2022-May-SJRC-Agenda.pdf" target="_blank" rel="noopener">Agenda</a>/<a href="http://sjrc.ca.gov/wp-content/uploads/2022/04/2022-May-SJRC-Board-Packet.pdf" target="_blank" rel="noopener">Packet</a>/<a href="http://sjrc.ca.gov/wp-content/uploads/2022/04/2022-February-SJRC-Draft-Minutes.pdf" target="_blank" rel="noopener">Draft February Minutes</a>/<a href="http://sjrc.ca.gov/wp-content/uploads/2022/04/2022-April-SJRC-Draft-Minutes.pdf" target="_blank" rel="noopener">Draft April Minutes</a></p>
+<p style="text-align: center;"><strong>August 3- Board Meeting</strong><br />
+<a href="http://sjrc.ca.gov/wp-content/uploads/2022/07/2022-August-SJRC-Agenda_Revised-1-1.pdf" target="_blank" rel="noopener">Agenda</a>/<a href="http://sjrc.ca.gov/wp-content/uploads/2022/07/2022-August-SJRC-Board-Packet-1.pdf">Packet</a>/<a href="http://sjrc.ca.gov/wp-content/uploads/2022/07/2022-May-SJRC-Draft-Minutes.pdf" target="_blank" rel="noopener">Draft Minutes</a>/<a href="http://sjrc.ca.gov/wp-content/uploads/2022/08/G-3_Executive_Officers_Report_2022_08.pdf" target="_blank" rel="noopener">Executive Officer&#8217;s Report</a></p>
+<p><a href="http://sjrc.ca.gov/wp-content/uploads/2022/08/Staff-presentation-for-Aug-2022.pptx" target="_blank" rel="noopener">PowerPoint for Meeting</a></p>
+<p><strong>September 7 &#8211; Board Meeting</strong></p>
+<p><a href="http://sjrc.ca.gov/wp-content/uploads/2022/08/2022-September-SJRC-Agenda.pdf" target="_blank" rel="noopener">Agenda</a>/<a href="http://sjrc.ca.gov/wp-content/uploads/2022/09/2022-September-SJRC-Board-Packet.pdf" target="_blank" rel="noopener">Packet</a>/<a href="http://sjrc.ca.gov/wp-content/uploads/2022/09/2022-August-SJRC-Draft-Minutes.pdf" target="_blank" rel="noopener">Draft Minutes</a>/<a href="http://sjrc.ca.gov/wp-content/uploads/2022/09/G-3-Executive-Officers-Report-2022-09.pdf" target="_blank" rel="noopener">Executive Officer&#8217;s Report</a></p>
+<p><a href="http://sjrc.ca.gov/wp-content/uploads/2022/09/Staff-presentation-for-Sept-2022.pptx" target="_blank" rel="noopener">PowerPoint for Meeting</a></p>
+<p style="text-align: center;"><strong>November 2- Board Meeting</strong><br />
+Agenda/Packet/Draft Minutes</p>
+<h3>Workshops</h3>
+<p><del>March 2- Workshop</del></p>
+<p><a href="http://sjrc.ca.gov/wp-content/uploads/2022/03/2022-SJRC-April-Workshop-Agenda.pdf" target="_blank" rel="noopener">April 6- Workshop</a></p>
+<p><a href="https://youtu.be/0vLZvDi90sE" target="_blank" rel="noopener">April 6 &#8211; SJRC Board Meeting/Workshop Webex Recording</a></p>
+<p><span style="text-decoration: line-through;">June 1- Workshop</span></p>
+<p>July– No meeting scheduled</p>
+<p><span style="text-decoration: line-through;">September 7- Workshop</span></p>
+<p>October 5- Workshop</p>
+<p>December 2-Workshop</p>
+<h2>2021 Meetings</h2>
+<h4>January 6 <a href="http://sjrc.ca.gov/wp-content/uploads/2020/12/2021-January-SJRC-Agenda.pdf">Agenda</a> / <a href="http://sjrc.ca.gov/wp-content/uploads/2020/12/2021-January-SJRC-Packet.pdf">Packet</a> / <a href="http://sjrc.ca.gov/wp-content/uploads/2021/02/2020-October-SJRC-Draft-Minutes.pdf" target="_blank" rel="noopener">Approved Minutes</a></h4>
+<p><a href="http://sjrc.ca.gov/wp-content/uploads/2021/01/Staff-presentation-for-Jan-2021.pdf" target="_blank" rel="noopener">PowerPoint Presentation (pdf)</a></p>
+<h4>March 3 <a href="http://sjrc.ca.gov/wp-content/uploads/2021/02/2021-March-SJRC-Agenda.pdf" target="_blank" rel="noopener">Agenda</a> / <a href="http://sjrc.ca.gov/wp-content/uploads/2021/02/2021-March-SJRC-Packet.pdf" target="_blank" rel="noopener">Packet </a>/ <a href="http://sjrc.ca.gov/wp-content/uploads/2021/02/2021-January-SJRC-Minutes.pdf" target="_blank" rel="noopener">Approved Minutes</a></h4>
+<p><a href="https://youtu.be/rfmGdXoUu8o" target="_blank" rel="noopener">Zoom Recording</a>/ <a href="http://sjrc.ca.gov/staff-presentation-for-march-2021/">PowerPoint Presentation (pdf)</a></p>
+<h4>April 7 <a href="http://sjrc.ca.gov/wp-content/uploads/2021/04/2021-April-SJRC-Agenda.pdf" target="_blank" rel="noopener">Agenda</a> / <a href="http://sjrc.ca.gov/wp-content/uploads/2021/04/2021-April-SJRC-Board-Packet.pdf" target="_blank" rel="noopener">Packet</a> / <a href="http://sjrc.ca.gov/wp-content/uploads/2021/08/2021-April-Draft-Minutes.pdf" target="_blank" rel="noopener">Draft Minutes</a></h4>
+<p><a href="https://youtu.be/db2MQqURH6E" target="_blank" rel="noopener">Zoom Recording</a>/ <a href="http://sjrc.ca.gov/wp-content/uploads/2021/04/Staff-presentation-for-April-2021.pdf" target="_blank" rel="noopener">PowerPoint Presentation (pdf)</a></p>
+<p>F-1 Handouts: <a href="http://sjrc.ca.gov/wp-content/uploads/2021/04/SJRPMP-Update-Map.pdf" target="_blank" rel="noopener">Map 1 </a> <a href="http://sjrc.ca.gov/wp-content/uploads/2021/04/SJRC-Planned-Trails-CEMEX.pdf" target="_blank" rel="noopener">Map 2 </a><a href="http://sjrc.ca.gov/wp-content/uploads/2021/04/Parkway-Trust-Item-F-1comments.pdf">Correspondence</a></p>
+<h4>September 1 <a href="http://sjrc.ca.gov/wp-content/uploads/2021/08/2021-September-Agenda.pdf" target="_blank" rel="noopener">Agenda</a> / <a href="http://sjrc.ca.gov/wp-content/uploads/2021/08/2021-September-Board-Packet.pdf" target="_blank" rel="noopener">Packet</a> / Draft Minutes</h4>
+<p><a href="https://us02web.zoom.us/j/82390725268" target="_blank" rel="noopener">Zoom Link</a> / <a href="http://sjrc.ca.gov/wp-content/uploads/2021/09/Staff-presentation-for-Sept-2021.pdf" target="_blank" rel="noopener">PowerPoint Presentation (pdf)</a></p>
+<h4>December 15</h4>
+<h4><a href="http://sjrc.ca.gov/wp-content/uploads/2021/12/2021-December-SJRC-Agenda.pdf" target="_blank" rel="noopener">Agenda</a> / <a href="http://sjrc.ca.gov/wp-content/uploads/2021/12/2021December-SJRC-Board-Packet.pdf" target="_blank" rel="noopener">Packet</a> / <a href="http://sjrc.ca.gov/wp-content/uploads/2021/12/2021-September-SJRC-Draft-Minutes.pdf" target="_blank" rel="noopener">Draft Minutes</a></h4>
+<p><a href="http://sjrc.ca.gov/wp-content/uploads/2021/12/G-3-Executive-Officers-Report-2021-12.pdf">Executive Officer&#8217;s Report</a></p>
+<p><a href="http://sjrc.ca.gov/wp-content/uploads/2021/12/121421.ConservancyFunding.pdf" target="_blank" rel="noopener">Correspondence</a></p>
+<p><a href="https://us06web.zoom.us/j/83003775408">Zoom Link</a>/<a href="http://sjrc.ca.gov/wp-content/uploads/2021/12/Staff-presentation-for-Dec-2021.pdf" target="_blank" rel="noopener">PowerPoint Presentation (pdf)</a></p>
+<h2><a href="http://sjrc.ca.gov/board/previous-board-meetings-packets/">Earlier Board Packets</a></h2>
+<p style="text-align: justify;">
+</td>
+</tr>
+</tbody>
+</table>
+	</article>
+      <!-- TemplateEndEditable --> </main>
+    </div>
+</div>
+
+
+
+
+
+
+<!-- Global Footer -->
+	<div class="container">
+	 			<!-- start v5 Bottom Blurb edit -->
+
+<!-- end v5 Bottom Blurb edit -->		 
+	</div>
+<footer id="footer" class="global-footer">
+  <div class="container">
+    <div class="row">
+      <div class="three-quarters">
+        <ul class="footer-links">
+          <li><a href="#skip-to-content">Back to Top</a></li>
+		   			<!-- start v5 Footer Info edit -->
+<li><a href="/accessibility/">Accessibility</a></li>
+<!-- end v5 Footer Info edit -->		 
+        </ul>
+      </div>
+      <div class="quarter text-right">
+        <ul class="socialsharer-container">
+           			<!-- start v5 Social Footer Info edit -->
+
+<!-- end v5 Social Footer Info edit -->		 
+        </ul>
+      </div>
+    </div>
+  </div>
+  <!-- Copyright Statement -->
+  <div class="copyright">
+	<div class="container">
+	 			<!-- start v5 Footer Address edit -->
+
+<!-- end v5 Footer Address edit -->		 
+ Copyright &copy; 2022 State of California 
+	</div>
+   </div>
+</footer>
+<!-- Extra Decorative Content -->
+<div class="decoration-last">&nbsp;</div>
+<!-- Load template core -->
+<script src="/js/cagov.core.js"></script>
+<script>
+$(document).ready(function() {
+    // Backward compatability fix for removing wrapper on new "sections"
+    $('.main-primary > .section').closest('div.wrapper').removeClass('wrapper');
+});
+</script></body>
+</html>

--- a/tests/test_san_joaquin_river_conservancy.py
+++ b/tests/test_san_joaquin_river_conservancy.py
@@ -1,0 +1,93 @@
+from datetime import datetime
+from os.path import dirname, join
+
+import pytest
+from city_scrapers_core.constants import BOARD
+from city_scrapers_core.utils import file_response
+from freezegun import freeze_time
+
+from city_scrapers.spiders.san_joaquin_river_conservancy import SanJoaquinRiverConservancySpider
+
+test_response = file_response(
+    join(dirname(__file__), "files", "san_joaquin_river_conservancy.html"),
+    url="http://sjrc.ca.gov/Board/",
+)
+spider = SanJoaquinRiverConservancySpider()
+
+freezer = freeze_time("2022-09-18")
+freezer.start()
+
+parsed_items = [item for item in spider.parse(test_response)]
+
+freezer.stop()
+
+def test_title():
+    assert parsed_items[0]["title"] == "February 2- Board Meeting "
+    assert parsed_items[1]["title"] == "April 6- Board Meeting"
+    assert parsed_items[2]["title"] == "May 4- Board Meeting"
+    assert parsed_items[3]["title"] == "August 3- Board Meeting"
+    assert parsed_items[4]["title"] == "September 7 – Board Meeting"
+    assert parsed_items[5]["title"] == "November 2- Board Meeting"
+
+@pytest.mark.parametrize("item", parsed_items)
+def test_description(item):
+    assert item["description"] == ""
+
+def test_start():
+    assert parsed_items[0]["start"] == datetime(2022, 2, 2, 10, 30)
+    assert parsed_items[1]["start"] == datetime(2022, 4, 6, 10, 00)
+    assert parsed_items[2]["start"] == datetime(2022, 5, 4, 10, 00)
+    assert parsed_items[3]["start"] == datetime(2022, 8, 3, 10, 00)
+    assert parsed_items[4]["start"] == datetime(2022, 9, 7, 10, 00)
+    assert parsed_items[5]["start"] == datetime(2022, 11, 2, 10, 30)
+
+
+def test_end():
+    assert parsed_items[0]["end"] == None
+
+@pytest.mark.parametrize("item", parsed_items)
+def test_time_notes(item):
+    time_notes_str = ("Scheduled meetings are subject to change. "
+                      "Refer to Agenda if available. For more information "
+                      "email info@sjrc.ca.gov or call (559) 253-7324.")
+    assert item["time_notes"] == time_notes_str
+
+# def test_id():
+#     assert parsed_items[0]["id"] == "EXPECTED ID"
+
+
+def test_status():
+    assert parsed_items[0]["status"] == "passed"
+    assert parsed_items[1]["status"] == "passed"
+    assert parsed_items[2]["status"] == "passed"
+    assert parsed_items[3]["status"] == "passed"
+    assert parsed_items[4]["status"] == "passed"
+    assert parsed_items[5]["status"] == "tentative"
+
+
+def test_location():
+    location_dict = { "address": "5469 E. Olive Ave., Fresno, CA 93727",
+            "name": "Fresno Metropolitan Flood Control District Board Room" }
+
+    assert parsed_items[0]["location"] == location_dict
+
+@pytest.mark.parametrize("item", parsed_items)
+def test_source(item):
+    assert item["source"] == "http://sjrc.ca.gov/Board/"
+
+def test_links():
+    link_dict = {'http://sjrc.ca.gov/wp-content/uploads/2022/01/2021-December-SJRC-Draft-Minutes.pdf': '2021-December-SJRC-Draft-Minutes',
+           'http://sjrc.ca.gov/wp-content/uploads/2022/01/2022-Feb-SJRC-Revised-Agenda.pdf': '2022-Feb-SJRC-Revised-Agenda',
+           'http://sjrc.ca.gov/wp-content/uploads/2022/01/2022-February-SJRC-Board-Packet.pdf': '2022-February-SJRC-Board-Packet',
+           'http://sjrc.ca.gov/wp-content/uploads/2022/02/BALL-RANCH.pdf': 'BALL-RANCH',
+           'http://sjrc.ca.gov/wp-content/uploads/2022/02/Staff-Presentation-for-Feb-2022.pdf': 'Staff-Presentation-for-Feb-2022'}
+    assert parsed_items[0]["links"] == link_dict
+
+@pytest.mark.parametrize("item", parsed_items)
+def test_classification(item):
+    assert item["classification"] == BOARD
+
+
+@pytest.mark.parametrize("item", parsed_items)
+def test_all_day(item):
+    assert item["all_day"] is False

--- a/tests/test_san_joaquin_river_conservancy.py
+++ b/tests/test_san_joaquin_river_conservancy.py
@@ -6,7 +6,9 @@ from city_scrapers_core.constants import BOARD
 from city_scrapers_core.utils import file_response
 from freezegun import freeze_time
 
-from city_scrapers.spiders.san_joaquin_river_conservancy import SanJoaquinRiverConservancySpider
+from city_scrapers.spiders.san_joaquin_river_conservancy import (
+    SanJoaquinRiverConservancySpider,
+)
 
 test_response = file_response(
     join(dirname(__file__), "files", "san_joaquin_river_conservancy.html"),
@@ -21,6 +23,7 @@ parsed_items = [item for item in spider.parse(test_response)]
 
 freezer.stop()
 
+
 def test_title():
     assert parsed_items[0]["title"] == "February 2- Board Meeting "
     assert parsed_items[1]["title"] == "April 6- Board Meeting"
@@ -29,9 +32,11 @@ def test_title():
     assert parsed_items[4]["title"] == "September 7 – Board Meeting"
     assert parsed_items[5]["title"] == "November 2- Board Meeting"
 
+
 @pytest.mark.parametrize("item", parsed_items)
 def test_description(item):
     assert item["description"] == ""
+
 
 def test_start():
     assert parsed_items[0]["start"] == datetime(2022, 2, 2, 10, 30)
@@ -42,18 +47,25 @@ def test_start():
     assert parsed_items[5]["start"] == datetime(2022, 11, 2, 10, 30)
 
 
-def test_end():
-    assert parsed_items[0]["end"] == None
-
 @pytest.mark.parametrize("item", parsed_items)
 def test_time_notes(item):
-    time_notes_str = ("Scheduled meetings are subject to change. "
-                      "Refer to Agenda if available. For more information "
-                      "email info@sjrc.ca.gov or call (559) 253-7324.")
+    time_notes_str = (
+        "Scheduled meetings are subject to change. "
+        "Refer to Agenda if available. For more information "
+        "email info@sjrc.ca.gov or call (559) 253-7324."
+    )
     assert item["time_notes"] == time_notes_str
 
-# def test_id():
-#     assert parsed_items[0]["id"] == "EXPECTED ID"
+
+def test_id():
+    assert (
+        parsed_items[0]["id"]
+        == "san_joaquin_river_conservancy/202202021030/x/february_2_board_meeting"
+    )
+    assert (
+        parsed_items[5]["id"]
+        == "san_joaquin_river_conservancy/202211021030/x/november_2_board_meeting"
+    )
 
 
 def test_status():
@@ -66,22 +78,43 @@ def test_status():
 
 
 def test_location():
-    location_dict = { "address": "5469 E. Olive Ave., Fresno, CA 93727",
-            "name": "Fresno Metropolitan Flood Control District Board Room" }
+    location_dict = {
+        "address": "5469 E. Olive Ave., Fresno, CA 93727",
+        "name": "Fresno Metropolitan Flood Control District Board Room",
+    }
 
     assert parsed_items[0]["location"] == location_dict
+
 
 @pytest.mark.parametrize("item", parsed_items)
 def test_source(item):
     assert item["source"] == "http://sjrc.ca.gov/Board/"
 
+
 def test_links():
-    link_dict = {'http://sjrc.ca.gov/wp-content/uploads/2022/01/2021-December-SJRC-Draft-Minutes.pdf': '2021-December-SJRC-Draft-Minutes',
-           'http://sjrc.ca.gov/wp-content/uploads/2022/01/2022-Feb-SJRC-Revised-Agenda.pdf': '2022-Feb-SJRC-Revised-Agenda',
-           'http://sjrc.ca.gov/wp-content/uploads/2022/01/2022-February-SJRC-Board-Packet.pdf': '2022-February-SJRC-Board-Packet',
-           'http://sjrc.ca.gov/wp-content/uploads/2022/02/BALL-RANCH.pdf': 'BALL-RANCH',
-           'http://sjrc.ca.gov/wp-content/uploads/2022/02/Staff-Presentation-for-Feb-2022.pdf': 'Staff-Presentation-for-Feb-2022'}
+    link_dict = {
+        (
+            "http://sjrc.ca.gov/wp-content/uploads/2022/01/"
+            "2021-December-SJRC-Draft-Minutes.pdf"
+        ): "2021-December-SJRC-Draft-Minutes",
+        (
+            "http://sjrc.ca.gov/wp-content/uploads/2022/01/"
+            "2022-Feb-SJRC-Revised-Agenda.pdf"
+        ): "2022-Feb-SJRC-Revised-Agenda",
+        (
+            "http://sjrc.ca.gov/wp-content/uploads/2022/01/"
+            "2022-February-SJRC-Board-Packet.pdf"
+        ): "2022-February-SJRC-Board-Packet",
+        (
+            "http://sjrc.ca.gov/wp-content/uploads/2022/02/" "BALL-RANCH.pdf"
+        ): "BALL-RANCH",
+        (
+            "http://sjrc.ca.gov/wp-content/uploads/2022/02/"
+            "Staff-Presentation-for-Feb-2022.pdf"
+        ): "Staff-Presentation-for-Feb-2022",
+    }
     assert parsed_items[0]["links"] == link_dict
+
 
 @pytest.mark.parametrize("item", parsed_items)
 def test_classification(item):


### PR DESCRIPTION
## Summary

**Issue:** #46 

Hello, here is my Pull Request that has my Spider and corresponding tests for the San Joaquin River Conservancy.
This site was a little difficult to parse since all of the meeting links and labels were siblings and had inconsistent formatting.
The solution I came up with was to parse through the elements sequentially into a dictionary, where the keys are meeting titles and the values are their corresponding links.

On the website, the meeting times are stated to be 10:00 AM between March and October, and 10:30 AM otherwise. I found this to be mostly consistent for the 2021 Meetings, but the 2022 meetings seem to deviate more often. The only way I see to get more accurate meeting times would be to parse the Agenda pdfs.

This is my first pull request on this project, so please let me know if there are any revisions I should make or if there are any suggestions I should consider.


## Checklist

All checks are run in [GitHub Actions](https://github.com/features/actions). You'll be able to see the results of the checks at the bottom of the pull request page after it's been opened, and you can click on any of the specific checks listed to see the output of each step and debug failures.

- [ ] Tests are implemented
- [ ] All tests are passing
- [ ] Style checks run (see [documentation](https://cityscrapers.org/docs/development/) for more details)
- [ ] Style checks are passing
- [ ] Code comments from template removed

## Questions

I didn't see any packages like `PyPDF2` in the `Pipfile`, but I was wondering: is that something we might add in the future to support parsing information from PDFs?

Also, should our spiders focus on parsing information from the most current meetings? Or should they be able to parse any past information that might be available on the website?
