### PR TITLE
#99: San Joaquin River Conservancy Spider link dictionary revision

### DIFF
--- a/city_scrapers/spiders/san_joaquin_river_conservancy.py
+++ b/city_scrapers/spiders/san_joaquin_river_conservancy.py
@@ -120,12 +120,18 @@ class SanJoaquinRiverConservancySpider(CityScrapersSpider):
 
     def _parse_links(self, item):
         """Parse or generate links."""
-        link_dict = {}
+        link_list = []
+        link_hash_map = {}
         for sel in item[1]:
-            link = sel.css("::attr(href)").get()
-            title = link.split("/")[len(link.split("/")) - 1].split(".")[0]
-            link_dict[link] = title
-        return link_dict
+            link = sel.css("a::attr(href)").get().strip()
+            if not link_hash_map.get(link):
+                link_hash_map[str(link)] = 1
+                title = link.split("/")[len(link.split("/")) - 1].split(".")[0]
+                link_dict = {}
+                link_dict["href"] = link
+                link_dict["title"] = title
+                link_list.append(link_dict)
+        return link_list
 
     def _parse_source(self, response):
         """Parse or generate source."""

--- a/tests/test_san_joaquin_river_conservancy.py
+++ b/tests/test_san_joaquin_river_conservancy.py
@@ -92,28 +92,41 @@ def test_source(item):
 
 
 def test_links():
-    link_dict = {
-        (
-            "http://sjrc.ca.gov/wp-content/uploads/2022/01/"
-            "2021-December-SJRC-Draft-Minutes.pdf"
-        ): "2021-December-SJRC-Draft-Minutes",
-        (
-            "http://sjrc.ca.gov/wp-content/uploads/2022/01/"
-            "2022-Feb-SJRC-Revised-Agenda.pdf"
-        ): "2022-Feb-SJRC-Revised-Agenda",
-        (
-            "http://sjrc.ca.gov/wp-content/uploads/2022/01/"
-            "2022-February-SJRC-Board-Packet.pdf"
-        ): "2022-February-SJRC-Board-Packet",
-        (
-            "http://sjrc.ca.gov/wp-content/uploads/2022/02/" "BALL-RANCH.pdf"
-        ): "BALL-RANCH",
-        (
-            "http://sjrc.ca.gov/wp-content/uploads/2022/02/"
-            "Staff-Presentation-for-Feb-2022.pdf"
-        ): "Staff-Presentation-for-Feb-2022",
-    }
-    assert parsed_items[0]["links"] == link_dict
+    link_list = [
+        {
+            "href": (
+                "http://sjrc.ca.gov/wp-content/uploads/2022/01/"
+                "2022-Feb-SJRC-Revised-Agenda.pdf"
+            ),
+            "title": "2022-Feb-SJRC-Revised-Agenda",
+        },
+        {
+            "href": (
+                "http://sjrc.ca.gov/wp-content/uploads/2022/01/"
+                "2022-February-SJRC-Board-Packet.pdf"
+            ),
+            "title": "2022-February-SJRC-Board-Packet",
+        },
+        {
+            "href": (
+                "http://sjrc.ca.gov/wp-content/uploads/2022/01/"
+                "2021-December-SJRC-Draft-Minutes.pdf"
+            ),
+            "title": "2021-December-SJRC-Draft-Minutes",
+        },
+        {
+            "href": (
+                "http://sjrc.ca.gov/wp-content/uploads/2022/02/"
+                "Staff-Presentation-for-Feb-2022.pdf"
+            ),
+            "title": "Staff-Presentation-for-Feb-2022",
+        },
+        {
+            "href": ("http://sjrc.ca.gov/wp-content/uploads/2022/02/BALL-RANCH.pdf"),
+            "title": "BALL-RANCH",
+        },
+    ]
+    assert parsed_items[0]["links"] == link_list
 
 
 @pytest.mark.parametrize("item", parsed_items)


### PR DESCRIPTION
## Summary

**Issue:** #99 

Revising the San Joaquin River Conservancy Spider `_parse_links()` function to return a dictionary with the proper format.

## Checklist

All checks are run in [GitHub Actions](https://github.com/features/actions). You'll be able to see the results of the checks at the bottom of the pull request page after it's been opened, and you can click on any of the specific checks listed to see the output of each step and debug failures.

- [ ] Tests are implemented
- [ ] All tests are passing
- [ ] Style checks run (see [documentation](https://cityscrapers.org/docs/development/) for more details)
- [ ] Style checks are passing
- [ ] Code comments from template removed

## Questions

